### PR TITLE
Agregar paginación a endpoints de usuarios y embarcaciones y añadir endpoints de búsqueda con documentación Swagger

### DIFF
--- a/backend/IncaCore/src/main/java/com/Incamar/IncaCore/controllers/EmbarcacionController.java
+++ b/backend/IncaCore/src/main/java/com/Incamar/IncaCore/controllers/EmbarcacionController.java
@@ -1,11 +1,16 @@
 package com.Incamar.IncaCore.controllers;
 
 import com.Incamar.IncaCore.documentation.embarcacion.*;
+import com.Incamar.IncaCore.documentation.user.SearchUsersEndpointDoc;
+import com.Incamar.IncaCore.dtos.users.UserResponseDto;
 import com.Incamar.IncaCore.models.Embarcacion;
 import com.Incamar.IncaCore.services.IEmbarcacionService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -25,8 +30,8 @@ public class EmbarcacionController {
     @GetAllEmbarcacionesEndpointDoc
     @PreAuthorize("hasAnyRole('WAREHOUSE_STAFF', 'OPERATIONS_MANAGER', 'ADMIN')")
     @GetMapping
-    public ResponseEntity<List<Embarcacion>> getAllEmbarcaciones() {
-        return ResponseEntity.ok(embarcacionService.getAllEmbarcaciones());
+    public ResponseEntity<Page<Embarcacion>> getAllEmbarcaciones(@ParameterObject Pageable pageable) {
+        return ResponseEntity.ok(embarcacionService.getAllEmbarcaciones(pageable));
     }
 
     @GetEmbarcacionByIdEndpointDoc
@@ -70,5 +75,13 @@ public class EmbarcacionController {
                                                        @Valid @RequestBody Embarcacion embarcacion) {
         Embarcacion updatedEmbarcacion = embarcacionService.editEmbarcacion(id, embarcacion);
         return ResponseEntity.ok(updatedEmbarcacion);
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @SearchEmbarcacionesEndpointDoc
+    @GetMapping("/search")
+    public ResponseEntity<Page<Embarcacion>> searchEmbarcaciones(@RequestParam("nombre") String nombre, @ParameterObject Pageable pageable) {
+        Page<Embarcacion> result = embarcacionService.searchEmbarcacionesByName(nombre, pageable);
+        return ResponseEntity.ok(result);
     }
 }

--- a/backend/IncaCore/src/main/java/com/Incamar/IncaCore/controllers/UserController.java
+++ b/backend/IncaCore/src/main/java/com/Incamar/IncaCore/controllers/UserController.java
@@ -7,9 +7,13 @@ import com.Incamar.IncaCore.enums.Role;
 import com.Incamar.IncaCore.models.User;
 import com.Incamar.IncaCore.services.UserService;
 import com.Incamar.IncaCore.utils.ApiResult;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -30,8 +34,8 @@ public class UserController {
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/getAllUsers")
     @GetAllUsersEndpointDoc
-    public ResponseEntity<ApiResult<?>> getAllUsers() {
-        List<UserResponseDto> users = userService.getAllUsers();
+    public ResponseEntity<ApiResult<?>> getAllUsers(@ParameterObject Pageable pageable) {
+        Page<UserResponseDto> users = userService.getAllUsers(pageable);
         return ResponseEntity.ok(ApiResult.success(users,
             "Se enviaron correctamente la lista de usuarios."));
     }
@@ -78,6 +82,14 @@ public class UserController {
                                                        @Valid @RequestBody UserRequestDto request) {
         User updatedUser =userService.editUser(id, request);
         return ResponseEntity.ok(updatedUser);
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/search")
+    @SearchUsersEndpointDoc
+    public ResponseEntity<Page<UserResponseDto>> searchUsers(@RequestParam("username") String username, @ParameterObject Pageable pageable) {
+        Page<UserResponseDto> result = userService.searchUsersByUsername(username, pageable);
+        return ResponseEntity.ok(result);
     }
 
 

--- a/backend/IncaCore/src/main/java/com/Incamar/IncaCore/documentation/embarcacion/SearchEmbarcacionesEndpointDoc.java
+++ b/backend/IncaCore/src/main/java/com/Incamar/IncaCore/documentation/embarcacion/SearchEmbarcacionesEndpointDoc.java
@@ -2,7 +2,6 @@ package com.Incamar.IncaCore.documentation.embarcacion;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -10,25 +9,22 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
 import java.lang.annotation.*;
 
-/**
- * Swagger documentation for GET /api/embarcaciones.
- */
-
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Operation(
-        summary = "Obtener todas las embarcaciones",
+        summary = "Buscar embarcaciones por nombre con paginación",
         description = """
-        Retorna una lista completa de embarcaciones registradas en el sistema. \
-        Accesible para usuarios con roles: <strong>WAREHOUSE_STAFF, OPERATIONS_MANAGER, o ADMIN.</strong>
+        Retorna una lista paginada de embarcaciones cuyo nombre coincida parcialmente \
+        (ignorando mayúsculas) con el valor proporcionado en el parámetro `nombre`. \
+        <strong>Solo accesible para usuarios con rol ADMIN.</strong>
         """,
         security = @SecurityRequirement(name = "bearer-key")
 )
 @ApiResponses(value = {
         @ApiResponse(
                 responseCode = "200",
-                description = "Lista paginada de embarcaciones obtenida exitosamente",
+                description = "Embarcaciones encontradas exitosamente",
                 content = @Content(
                         mediaType = "application/json",
                         schema = @Schema(example = """
@@ -36,67 +32,35 @@ import java.lang.annotation.*;
                   "content": [
                     {
                       "id": 1,
-                      "nombre": "Embarcación A",
+                      "nombre": "Santa María",
                       "nPatente": "ABC123",
-                      "modelo": "Modelo 2023",
-                      "capitan": "Juan Pérez"
+                      "capitan": "Juan Pérez",
+                      "modelo": "Pesquero"
                     },
                     {
                       "id": 2,
-                      "nombre": "Embarcación B",
-                      "nPatente": "DEF456",
-                      "modelo": "Modelo 2022",
-                      "capitan": "María López"
+                      "nombre": "Mar Azul",
+                      "nPatente": "XYZ456",
+                      "capitan": "Pedro López",
+                      "modelo": "Velero"
                     }
                   ],
                   "pageable": {
-                    "sort": {
-                      "sorted": false,
-                      "unsorted": true,
-                      "empty": true
-                    },
                     "pageNumber": 0,
-                    "pageSize": 10,
-                    "offset": 0,
-                    "paged": true,
-                    "unpaged": false
+                    "pageSize": 10
                   },
                   "totalElements": 2,
                   "totalPages": 1,
                   "last": true,
                   "first": true,
-                  "sort": {
-                    "sorted": false,
-                    "unsorted": true,
-                    "empty": true
-                  },
-                  "numberOfElements": 2,
-                  "size": 10,
-                  "number": 0,
                   "empty": false
                 }
                 """)
                 )
         ),
         @ApiResponse(
-                responseCode = "401",
-                description = "No autorizado (token ausente o inválido)",
-                content = @Content(
-                        mediaType = "application/json",
-                        schema = @Schema(example = """
-                {
-                  "statusCode": 401,
-                  "message": "Acceso no autorizado",
-                  "errorCode": "UNAUTHORIZED",
-                  "details": "...",
-                  "path": "/api/embarcaciones"
-                }
-            """)
-                )
-        ),
-        @ApiResponse(
                 responseCode = "403",
-                description = "Acceso denegado por falta de permisos",
+                description = "Acceso denegado por falta de permisos. Usuario con rol no autorizado.",
                 content = @Content(
                         mediaType = "application/json",
                         schema = @Schema(example = """
@@ -105,23 +69,23 @@ import java.lang.annotation.*;
                   "message": "Acceso denegado",
                   "errorCode": "FORBIDDEN",
                   "details": "...",
-                  "path": "/api/embarcaciones"
+                  "path": "/api/embarcaciones/search"
                 }
             """)
                 )
         ),
         @ApiResponse(
-                responseCode = "404",
-                description = "Recurso no encontrado (en este contexto podría aplicarse si no hay embarcaciones registradas)",
+                responseCode = "401",
+                description = "No autorizado (token ausente o inválido).",
                 content = @Content(
                         mediaType = "application/json",
                         schema = @Schema(example = """
                 {
-                  "statusCode": 404,
-                  "message": "No se encontraron embarcaciones registradas.",
-                  "errorCode": "NOT_FOUND",
+                  "statusCode": 401,
+                  "message": "Acceso no autorizado",
+                  "errorCode": "AUTH_ERROR",
                   "details": "...",
-                  "path": "/api/embarcaciones"
+                  "path": "/api/embarcaciones/search"
                 }
             """)
                 )
@@ -137,11 +101,11 @@ import java.lang.annotation.*;
                   "message": "Error inesperado",
                   "errorCode": "INTERNAL_SERVER_ERROR",
                   "details": "...",
-                  "path": "/api/embarcaciones"
+                  "path": "/api/embarcaciones/search"
                 }
-            """)
+                """)
                 )
         )
 })
-public @interface GetAllEmbarcacionesEndpointDoc {}
+public @interface SearchEmbarcacionesEndpointDoc {}
 

--- a/backend/IncaCore/src/main/java/com/Incamar/IncaCore/documentation/user/GetAllUsersEndpointDoc.java
+++ b/backend/IncaCore/src/main/java/com/Incamar/IncaCore/documentation/user/GetAllUsersEndpointDoc.java
@@ -19,32 +19,57 @@ import java.lang.annotation.Target;
 @Operation(
     summary = "Obtener todos los usuarios",
     description = """
-        Retorna la lista completa de usuarios del sistema. \
+        Retorna la lista paginada de usuarios del sistema. \
         <strong>Solo accesible para usuarios con rol ADMIN.</strong>
         """,
         security = @SecurityRequirement(name = "bearer-key")
 )
 @ApiResponses(value = {
-    @ApiResponse(
-        responseCode = "200",
-        description = "Lista de usuarios obtenida exitosamente",
-        content = @Content(
-            mediaType = "application/json",
-            schema = @Schema(example = """
+        @ApiResponse(
+                responseCode = "200",
+                description = "Lista paginada de usuarios obtenida exitosamente",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(example = """
                 {
-                  "success": true,
-                  "message": "Se enviaron correctamente la lista de usuarios.",
-                  "data": [
+                  "content": [
                     {
                       "uuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
                       "username": "juanperez",
                       "role": "ADMIN"
+                    },
+                    {
+                      "uuid": "3fa85f64-5717-4562-b3fc-2c963f66af01",
+                      "username": "mariagarcia",
+                      "role": "USER"
                     }
-                  ]
+                  ],
+                  "pageable": {
+                    "pageNumber": 0,
+                    "pageSize": 10,
+                    "sort": {
+                      "sorted": true,
+                      "unsorted": false,
+                      "empty": false
+                    }
+                  },
+                  "totalPages": 5,
+                  "totalElements": 50,
+                  "last": false,
+                  "size": 10,
+                  "number": 0,
+                  "sort": {
+                    "sorted": true,
+                    "unsorted": false,
+                    "empty": false
+                  },
+                  "first": true,
+                  "numberOfElements": 10,
+                  "empty": false
                 }
                 """)
-        )
-    ),
+                )
+        ),
     @ApiResponse(
         responseCode = "404",
         description = "Usuario no encontrado",

--- a/backend/IncaCore/src/main/java/com/Incamar/IncaCore/documentation/user/SearchUsersEndpointDoc.java
+++ b/backend/IncaCore/src/main/java/com/Incamar/IncaCore/documentation/user/SearchUsersEndpointDoc.java
@@ -1,0 +1,107 @@
+package com.Incamar.IncaCore.documentation.user;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+        summary = "Buscar usuarios por nombre de usuario con paginación",
+        description = """
+        Retorna una lista paginada de usuarios cuyo nombre de usuario coincida parcialmente \
+        (ignorando mayúsculas) con el valor proporcionado en el parámetro `username`. \
+        <strong>Solo accesible para usuarios con rol ADMIN.</strong>
+        """,
+        security = @SecurityRequirement(name = "bearer-key")
+)
+@ApiResponses(value = {
+        @ApiResponse(
+                responseCode = "200",
+                description = "Usuarios encontrados exitosamente",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(example = """
+                {
+                  "content": [
+                    {
+                      "uuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                      "username": "edgar123",
+                      "role": "USER"
+                    },
+                    {
+                      "uuid": "6f4b3b4e-2f21-478a-857e-7cfe546d35fa",
+                      "username": "eduardo",
+                      "role": "ADMIN"
+                    }
+                  ],
+                  "pageable": {
+                    "pageNumber": 0,
+                    "pageSize": 10
+                  },
+                  "totalElements": 2,
+                  "totalPages": 1,
+                  "last": true,
+                  "first": true,
+                  "empty": false
+                }
+                """)
+                )
+        ),
+        @ApiResponse(
+                responseCode = "403",
+                description = "Acceso denegado por falta de permisos. Usuario con rol no autorizado.",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(example = """
+                {
+                  "statusCode": 403,
+                  "message": "Acceso denegado",
+                  "errorCode": "FORBIDDEN",
+                  "details": "...",
+                  "path": "/api/users/search"
+                }
+            """)
+                )
+        ),
+        @ApiResponse(
+                responseCode = "401",
+                description = "No autorizado (token ausente o inválido).",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(example = """
+                {
+                  "statusCode": 401,
+                  "message": "Acceso no autorizado",
+                  "errorCode": "AUTH_ERROR",
+                  "details": "...",
+                  "path": "/api/users/search"
+                }
+            """)
+                )
+        ),
+        @ApiResponse(
+                responseCode = "500",
+                description = "Error interno del servidor",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(example = """
+                {
+                  "statusCode": 500,
+                  "message": "Error inesperado",
+                  "errorCode": "INTERNAL_SERVER_ERROR",
+                  "details": "...",
+                  "path": "/api/users/search"
+                }
+                """)
+                )
+        )
+})
+public @interface SearchUsersEndpointDoc {}
+

--- a/backend/IncaCore/src/main/java/com/Incamar/IncaCore/models/User.java
+++ b/backend/IncaCore/src/main/java/com/Incamar/IncaCore/models/User.java
@@ -90,7 +90,6 @@ public class User implements UserDetails {
   }
 
   @Override
-  @Transient
   public String getUsername() {
     return username;
   }

--- a/backend/IncaCore/src/main/java/com/Incamar/IncaCore/repositories/EmbarcacionRepository.java
+++ b/backend/IncaCore/src/main/java/com/Incamar/IncaCore/repositories/EmbarcacionRepository.java
@@ -1,9 +1,14 @@
 package com.Incamar.IncaCore.repositories;
 
 import com.Incamar.IncaCore.models.Embarcacion;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface EmbarcacionRepository extends JpaRepository<Embarcacion,Long> {
+
+    Page<Embarcacion> findByNombreContainingIgnoreCase(String nombreParcial, Pageable pageable);
+
 }

--- a/backend/IncaCore/src/main/java/com/Incamar/IncaCore/repositories/UserRepository.java
+++ b/backend/IncaCore/src/main/java/com/Incamar/IncaCore/repositories/UserRepository.java
@@ -1,7 +1,11 @@
 package com.Incamar.IncaCore.repositories;
 
 import com.Incamar.IncaCore.models.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -12,4 +16,7 @@ public interface UserRepository extends JpaRepository<User, UUID> {
   Optional<User> findByUsername(String username);
 
   boolean existsByUsername(String username);
+
+  Page<User> findByUsernameContainingIgnoreCase(String nombre, Pageable pageable);
+
 }

--- a/backend/IncaCore/src/main/java/com/Incamar/IncaCore/services/EmbarcacionService.java
+++ b/backend/IncaCore/src/main/java/com/Incamar/IncaCore/services/EmbarcacionService.java
@@ -4,6 +4,8 @@ import com.Incamar.IncaCore.exceptions.ResourceNotFoundException;
 import com.Incamar.IncaCore.models.Embarcacion;
 import com.Incamar.IncaCore.repositories.EmbarcacionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -15,8 +17,8 @@ public class EmbarcacionService implements  IEmbarcacionService{
     EmbarcacionRepository embarcacionRepository;
 
     @Override
-    public List<Embarcacion> getAllEmbarcaciones() {
-        return embarcacionRepository.findAll();
+    public Page<Embarcacion> getAllEmbarcaciones(Pageable pageable) {
+        return embarcacionRepository.findAll(pageable);
     }
 
     @Override
@@ -55,5 +57,10 @@ public class EmbarcacionService implements  IEmbarcacionService{
         auxEmbarcacion.setModelo(embarcacion.getModelo());
 
         return embarcacionRepository.save(auxEmbarcacion);
+    }
+
+    @Override
+    public Page<Embarcacion> searchEmbarcacionesByName(String nombre, Pageable pageable) {
+        return embarcacionRepository.findByNombreContainingIgnoreCase(nombre,pageable);
     }
 }

--- a/backend/IncaCore/src/main/java/com/Incamar/IncaCore/services/IEmbarcacionService.java
+++ b/backend/IncaCore/src/main/java/com/Incamar/IncaCore/services/IEmbarcacionService.java
@@ -1,13 +1,17 @@
 package com.Incamar.IncaCore.services;
 
+import com.Incamar.IncaCore.dtos.users.UserResponseDto;
 import com.Incamar.IncaCore.models.Embarcacion;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface IEmbarcacionService {
-    List<Embarcacion> getAllEmbarcaciones();
+    Page<Embarcacion> getAllEmbarcaciones(Pageable pageable);
     Embarcacion getEmbarcacionById(Long id);
     void createEmbarcacion(String nombre, String nPatente, String capitan, String modelo);
     void deleteEmbarcacionById(Long id);
     Embarcacion editEmbarcacion(Long id, Embarcacion embarcacion);
+    Page<Embarcacion> searchEmbarcacionesByName(String nombre, Pageable pageable);
 }

--- a/backend/IncaCore/src/main/java/com/Incamar/IncaCore/services/IUserService.java
+++ b/backend/IncaCore/src/main/java/com/Incamar/IncaCore/services/IUserService.java
@@ -5,15 +5,18 @@ import com.Incamar.IncaCore.dtos.users.UserRequestDto;
 import com.Incamar.IncaCore.dtos.users.UserResponseDto;
 import com.Incamar.IncaCore.enums.Role;
 import com.Incamar.IncaCore.models.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
 public interface IUserService {
-    List<UserResponseDto> getAllUsers();
+    Page<UserResponseDto> getAllUsers(Pageable pageable);
     UserResponseDto getUser(JwtDataDto jwtDataDto, UUID id);
     void createUser(String username, String password, Role role, LocalDateTime createdAt);
     void deleteUserById(UUID id);
     User editUser(UUID id, UserRequestDto request);
+    Page<UserResponseDto>searchUsersByUsername(String username, Pageable pageable);
 }

--- a/backend/IncaCore/src/main/java/com/Incamar/IncaCore/services/UserService.java
+++ b/backend/IncaCore/src/main/java/com/Incamar/IncaCore/services/UserService.java
@@ -11,6 +11,8 @@ import com.Incamar.IncaCore.mappers.UserMapper;
 import com.Incamar.IncaCore.models.User;
 import com.Incamar.IncaCore.repositories.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -19,7 +21,6 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -35,11 +36,9 @@ public class UserService implements UserDetailsService, IUserService {
   }
 
   @Override
-  public List<UserResponseDto> getAllUsers() {
-    List<User> users = userRepository.findAll();
-    return users.stream()
-        .map(userMapper::toDTO)
-        .collect(Collectors.toList());
+  public Page<UserResponseDto> getAllUsers(Pageable pageable) {
+    Page<User> userPage = userRepository.findAll(pageable);
+    return userPage.map(userMapper::toDTO);
   }
 
   @Override
@@ -89,5 +88,12 @@ public class UserService implements UserDetailsService, IUserService {
     auxUser.setCreatedAt(request.getCreatedAt());
 
     return userRepository.save(auxUser);
+  }
+
+  @Override
+  public Page<UserResponseDto> searchUsersByUsername(String username, Pageable pageable) {
+    return userRepository
+            .findByUsernameContainingIgnoreCase(username, pageable)
+            .map(userMapper::toDTO);
   }
 }


### PR DESCRIPTION
- Se implementó paginación en los endpoints que retornaban todos los usuarios y todas las embarcaciones.
- Se añadieron nuevos endpoints para búsqueda paginada de usuarios y embarcaciones por nombre.
- Se creó la documentación Swagger detallada para los endpoints de búsqueda, incluyendo ejemplos de respuesta y manejo de errores.