### PR TITLE
Add vessels (vassels) management feature to frontend

### DIFF
--- a/frontend/src/app/(main)/sidebar/page.tsx
+++ b/frontend/src/app/(main)/sidebar/page.tsx
@@ -165,7 +165,7 @@ const defaultMenuItems: MenuItem[] = [
   { id: "dashboard", label: "Dashboard", href: "/dashboard", icon: <DashboardIcon /> },
   { id: "users", label: "Usuarios", href: "/users", icon: <UsersIcon /> },
   { id: "maintenance", label: "Mantenimiento", href: "/maintenance", icon: <MaintenanceIcon /> },
-  { id: "boats", label: "Embarcaciones", href: "/boats", icon: <ShippingIcon /> },
+  { id: "vassels", label: "Embarcaciones", href: "/vassels", icon: <ShippingIcon /> },
   { id: "inventory", label: "Inventario", href: "/inventory", icon: <InventoryIcon /> },
   {
     id: "service-ticket",

--- a/frontend/src/app/(main)/vassels/page.tsx
+++ b/frontend/src/app/(main)/vassels/page.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { VasselsList } from "@/features/vassels";
+
+export default function VasselsPage() {
+  return <VasselsList />;
+}

--- a/frontend/src/components/UI/Sidebar.tsx
+++ b/frontend/src/components/UI/Sidebar.tsx
@@ -162,7 +162,7 @@ const defaultMenuItems: MenuItem[] = [
   { id: "dashboard", label: "Dashboard", href: "/dashboard", icon: <DashboardIcon /> },
   { id: "users", label: "Usuarios", href: "/users", icon: <UsersIcon /> },
   { id: "maintenance", label: "Mantenimiento", href: "/maintenance", icon: <MaintenanceIcon /> },
-  { id: "boats", label: "Embarcaciones", href: "/boats", icon: <ShippingIcon /> },
+  { id: "vassels", label: "Embarcaciones", href: "/vassels", icon: <ShippingIcon /> },
   { id: "inventory", label: "Inventario", href: "/inventory", icon: <InventoryIcon /> },
   { id: "config", label: "Configuración", href: "/config", icon: <ConfigIcon /> },
 ];

--- a/frontend/src/features/maintenance/components/MaintenanceForm.tsx
+++ b/frontend/src/features/maintenance/components/MaintenanceForm.tsx
@@ -19,7 +19,6 @@ import { MaintenanceListItem, maintenanceService } from "@/features/maintenance"
 
 import { vasselsService, type Vassel } from "@/features/vassels";
 
-
 const { TextArea } = Input;
 
 interface Props {
@@ -57,7 +56,6 @@ export const MaintenanceForm: React.FC<Props> = ({
     defaultValues,
   });
 
-
   // Cargar embarcaciones para el select
   const [vassels, setVassels] = React.useState<Vassel[]>([]);
   useEffect(() => {
@@ -83,7 +81,6 @@ export const MaintenanceForm: React.FC<Props> = ({
 
   const onSubmit: SubmitHandler<MaintenanceFormValues> = async (data) => {
     try {
-
       // Incluir vesselId si el usuario eligió una embarcación válida
       const selected = vassels.find((v) => v.name === data.vesselName);
       const payload: Partial<MaintenanceListItem> = selected
@@ -126,7 +123,6 @@ export const MaintenanceForm: React.FC<Props> = ({
             control={control}
             name="vesselName"
             render={({ field }) => (
-
               <Select
                 id="vesselName"
                 showSearch
@@ -135,7 +131,6 @@ export const MaintenanceForm: React.FC<Props> = ({
                 value={field.value ?? undefined}
                 onChange={(val) => field.onChange(val)}
                 options={vassels.map((v) => ({ label: v.name, value: v.name }))}
-
               />
             )}
           />

--- a/frontend/src/features/vassels/components/VasselsForm.tsx
+++ b/frontend/src/features/vassels/components/VasselsForm.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import React from "react";
+import { Controller, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Input, InputNumber, Button } from "antd";
+import { vasselSchema, type VasselFormValues } from "@/features/vassels/schemas/vassel.schema";
+import { vasselsService, type Vassel } from "@/features/vassels";
+import { showAlert } from "@/utils/showAlert";
+
+interface Props {
+  current?: (Vassel & { id?: number }) | null;
+  onSaved?: (v: Vassel) => void;
+  onCancel?: () => void;
+}
+
+export default function VasselsForm({ current, onSaved, onCancel }: Props) {
+  const {
+    control,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    reset,
+  } = useForm<VasselFormValues>({
+    resolver: zodResolver(vasselSchema),
+    defaultValues: current ?? {
+      name: "",
+      registrationNumber: "",
+      ismm: "",
+      flagState: "",
+      callSign: "",
+      portOfRegistry: "",
+      rif: "",
+      serviceType: "",
+      constructionMaterial: "",
+      sternType: "",
+      fuelType: "",
+      navigationHours: 0,
+    },
+  });
+
+  React.useEffect(() => {
+    if (current) {
+      reset(current);
+    }
+  }, [current, reset]);
+
+  const onSubmit = async (values: VasselFormValues) => {
+    try {
+      let saved: Vassel;
+      if (current?.id) {
+        saved = await vasselsService.update(current.id, values);
+      } else {
+        saved = await vasselsService.create(values);
+      }
+      await showAlert("Éxito", "Embarcación guardada correctamente", "success");
+      onSaved?.(saved);
+      onCancel?.();
+    } catch (e) {
+      await showAlert("Error", (e as Error)?.message || "No se pudo guardar", "error");
+    }
+  };
+
+  // Allowed RIF prefix letters and type guard
+  const allowedLetters = ["J", "G", "V", "E", "P"] as const;
+  const isAllowedLetter = (c: string): c is (typeof allowedLetters)[number] =>
+    (allowedLetters as readonly string[]).includes(c);
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <div>
+          <label className="mb-1 block text-sm font-medium">Nombre</label>
+          <Controller
+            name="name"
+            control={control}
+            render={({ field }) => <Input {...field} status={errors.name ? "error" : undefined} />}
+          />
+          {errors.name ? <p className="mt-1 text-xs text-red-600">{errors.name.message}</p> : null}
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium">Matrícula</label>
+          <Controller
+            name="registrationNumber"
+            control={control}
+            render={({ field }) => (
+              <Input {...field} status={errors.registrationNumber ? "error" : undefined} />
+            )}
+          />
+          {errors.registrationNumber ? (
+            <p className="mt-1 text-xs text-red-600">{errors.registrationNumber.message}</p>
+          ) : null}
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium">ISMM</label>
+          <Controller
+            name="ismm"
+            control={control}
+            render={({ field }) => <Input {...field} status={errors.ismm ? "error" : undefined} />}
+          />
+          {errors.ismm ? <p className="mt-1 text-xs text-red-600">{errors.ismm.message}</p> : null}
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium">Bandera</label>
+          <Controller
+            name="flagState"
+            control={control}
+            render={({ field }) => (
+              <Input {...field} status={errors.flagState ? "error" : undefined} />
+            )}
+          />
+          {errors.flagState ? (
+            <p className="mt-1 text-xs text-red-600">{errors.flagState.message}</p>
+          ) : null}
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium">Señal de llamada</label>
+          <Controller
+            name="callSign"
+            control={control}
+            render={({ field }) => (
+              <Input {...field} status={errors.callSign ? "error" : undefined} />
+            )}
+          />
+          {errors.callSign ? (
+            <p className="mt-1 text-xs text-red-600">{errors.callSign.message}</p>
+          ) : null}
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium">Puerto de registro</label>
+          <Controller
+            name="portOfRegistry"
+            control={control}
+            render={({ field }) => (
+              <Input {...field} status={errors.portOfRegistry ? "error" : undefined} />
+            )}
+          />
+          {errors.portOfRegistry ? (
+            <p className="mt-1 text-xs text-red-600">{errors.portOfRegistry.message}</p>
+          ) : null}
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium">RIF</label>
+          <Controller
+            name="rif"
+            control={control}
+            render={({ field }) => (
+              <Input
+                {...field}
+                placeholder="J-12345678-9"
+                maxLength={12}
+                allowClear
+                onChange={(e) => {
+                  const prev = (field.value ?? "").toString().toUpperCase();
+                  const raw = (e.target.value ?? "").toString().toUpperCase();
+
+                  // Determine prefix letter
+                  const firstLetter = raw.replace(/[^A-Z]/g, "")[0] ?? "";
+                  const prevPrefix = isAllowedLetter(prev[0] ?? "") ? prev[0] : "";
+                  const prefix = isAllowedLetter(firstLetter) ? firstLetter : prevPrefix;
+
+                  // Gather digits
+                  const digits = raw.replace(/[^0-9]/g, "");
+                  const middle = digits.slice(0, 8);
+                  const last = digits.slice(8, 9);
+
+                  // Compose formatted value
+                  let formatted = prefix;
+                  if (prefix) formatted += "-";
+                  formatted += middle;
+                  if (prefix && middle.length === 8) formatted += "-";
+                  formatted += last;
+
+                  field.onChange(formatted);
+                }}
+                status={errors.rif ? "error" : undefined}
+              />
+            )}
+          />
+          {errors.rif ? (
+            <p className="mt-1 text-xs text-red-600">{errors.rif.message}</p>
+          ) : (
+            <p className="mt-1 text-xs text-gray-500">Formato: J-12345678-9</p>
+          )}
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium">Tipo de servicio</label>
+          <Controller
+            name="serviceType"
+            control={control}
+            render={({ field }) => (
+              <Input {...field} status={errors.serviceType ? "error" : undefined} />
+            )}
+          />
+          {errors.serviceType ? (
+            <p className="mt-1 text-xs text-red-600">{errors.serviceType.message}</p>
+          ) : null}
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium">Material de construcción</label>
+          <Controller
+            name="constructionMaterial"
+            control={control}
+            render={({ field }) => (
+              <Input {...field} status={errors.constructionMaterial ? "error" : undefined} />
+            )}
+          />
+          {errors.constructionMaterial ? (
+            <p className="mt-1 text-xs text-red-600">{errors.constructionMaterial.message}</p>
+          ) : null}
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium">Tipo de popa</label>
+          <Controller
+            name="sternType"
+            control={control}
+            render={({ field }) => (
+              <Input {...field} status={errors.sternType ? "error" : undefined} />
+            )}
+          />
+          {errors.sternType ? (
+            <p className="mt-1 text-xs text-red-600">{errors.sternType.message}</p>
+          ) : null}
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium">Tipo de combustible</label>
+          <Controller
+            name="fuelType"
+            control={control}
+            render={({ field }) => (
+              <Input {...field} status={errors.fuelType ? "error" : undefined} />
+            )}
+          />
+          {errors.fuelType ? (
+            <p className="mt-1 text-xs text-red-600">{errors.fuelType.message}</p>
+          ) : null}
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium">Horas de navegación</label>
+          <Controller
+            name="navigationHours"
+            control={control}
+            render={({ field }) => (
+              <InputNumber
+                {...field}
+                min={0}
+                className="w-full"
+                status={errors.navigationHours ? "error" : undefined}
+              />
+            )}
+          />
+          {errors.navigationHours ? (
+            <p className="mt-1 text-xs text-red-600">{errors.navigationHours.message as string}</p>
+          ) : null}
+        </div>
+      </div>
+      <div className="flex justify-end gap-2 pt-2">
+        <Button onClick={onCancel}>Cancelar</Button>
+        <Button type="primary" htmlType="submit" loading={isSubmitting}>
+          Guardar
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/features/vassels/components/VasselsList.tsx
+++ b/frontend/src/features/vassels/components/VasselsList.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Button, Input, Modal, Popconfirm, Space, Table, Tooltip } from "antd";
+import type { ColumnsType } from "antd/es/table";
+import type { TableProps } from "antd";
+import { PlusOutlined, EditOutlined, DeleteOutlined } from "@ant-design/icons";
+import { vasselsService, type Vassel } from "@/features/vassels";
+import VasselsForm from "@/features/vassels/components/VasselsForm";
+import { showAlert } from "@/utils/showAlert";
+
+export default function VasselsList() {
+  const [items, setItems] = useState<Vassel[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [dialog, setDialog] = useState(false);
+  const [current, setCurrent] = useState<Vassel | null>(null);
+  const [search, setSearch] = useState("");
+  const [tableSort, setTableSort] = useState<string | undefined>("id,desc");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await vasselsService.list({ page: 0, size: 100, sort: tableSort });
+      setItems(res.content ?? []);
+    } catch (e) {
+      await showAlert(
+        "Error al cargar",
+        (e as Error)?.message || "No se pudo cargar la lista de embarcaciones",
+        "error",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [tableSort]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const filtered = useMemo(() => {
+    const term = search.toLowerCase().trim();
+    if (!term) return items;
+    return items.filter((i) => {
+      return (
+        i.name.toLowerCase().includes(term) ||
+        i.registrationNumber.toLowerCase().includes(term) ||
+        i.flagState.toLowerCase().includes(term) ||
+        i.portOfRegistry.toLowerCase().includes(term) ||
+        i.rif.toLowerCase().includes(term) ||
+        i.serviceType.toLowerCase().includes(term) ||
+        i.constructionMaterial.toLowerCase().includes(term) ||
+        i.sternType.toLowerCase().includes(term) ||
+        i.fuelType.toLowerCase().includes(term)
+      );
+    });
+  }, [items, search]);
+
+  const handleTableChange: TableProps<Vassel>["onChange"] = (_pagination, _filters, sorter) => {
+    if (Array.isArray(sorter)) {
+      const s = sorter[0];
+      let order: "asc" | "desc" | undefined;
+      if (s?.order === "ascend") order = "asc";
+      else if (s?.order === "descend") order = "desc";
+      const field = (s?.field as string) || undefined;
+      setTableSort(order && field ? `${field},${order}` : undefined);
+    } else {
+      let order: "asc" | "desc" | undefined;
+      if (sorter.order === "ascend") order = "asc";
+      else if (sorter.order === "descend") order = "desc";
+      const field = (sorter.field as string) || undefined;
+      setTableSort(order && field ? `${field},${order}` : undefined);
+    }
+  };
+
+  const columns: ColumnsType<Vassel> = [
+    {
+      title: "ID",
+      dataIndex: "id",
+      key: "id",
+      width: 70,
+      sorter: true,
+      sortOrder:
+        tableSort && tableSort.startsWith("id,")
+          ? tableSort.endsWith("asc")
+            ? "ascend"
+            : tableSort.endsWith("desc")
+              ? "descend"
+              : undefined
+          : undefined,
+      render: (v: Vassel["id"]) => (v ?? "—") as React.ReactNode,
+    },
+    { title: "Nombre", dataIndex: "name", key: "name", sorter: true },
+    { title: "Matrícula", dataIndex: "registrationNumber", key: "registrationNumber" },
+    { title: "ISMM", dataIndex: "ismm", key: "ismm" },
+    { title: "Bandera", dataIndex: "flagState", key: "flagState" },
+    { title: "Señal", dataIndex: "callSign", key: "callSign" },
+    { title: "Puerto", dataIndex: "portOfRegistry", key: "portOfRegistry" },
+    { title: "RIF", dataIndex: "rif", key: "rif" },
+    { title: "Servicio", dataIndex: "serviceType", key: "serviceType" },
+    { title: "Material", dataIndex: "constructionMaterial", key: "constructionMaterial" },
+    { title: "Popa", dataIndex: "sternType", key: "sternType" },
+    { title: "Combustible", dataIndex: "fuelType", key: "fuelType" },
+    { title: "Horas", dataIndex: "navigationHours", key: "navigationHours", width: 100 },
+    {
+      title: "Acciones",
+      key: "acciones",
+      align: "right" as const,
+      render: (_: unknown, record) => (
+        <Space size="small" onClick={(e) => e.stopPropagation()}>
+          <Tooltip title="Editar">
+            <Button
+              size="small"
+              type="text"
+              icon={<EditOutlined />}
+              onClick={() => {
+                setCurrent(record);
+                setDialog(true);
+              }}
+            />
+          </Tooltip>
+          <Popconfirm
+            title="Confirmar eliminación"
+            okText="Eliminar"
+            cancelText="Cancelar"
+            onConfirm={async () => {
+              try {
+                await vasselsService.remove(record.id);
+                setItems((prev) => prev.filter((x) => x.id !== record.id));
+              } catch (e) {
+                await showAlert(
+                  "Error al eliminar",
+                  (e as Error)?.message || "No se pudo eliminar",
+                  "error",
+                );
+              }
+            }}
+          >
+            <Tooltip title="Eliminar">
+              <Button size="small" type="text" danger icon={<DeleteOutlined />} />
+            </Tooltip>
+          </Popconfirm>
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <main className="min-h-screen bg-gray-50 p-8">
+      <div className="mx-auto">
+        <header className="mb-8 flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900">Embarcaciones</h1>
+            <p className="mt-1 text-sm text-gray-600">Listado y gestión de embarcaciones.</p>
+          </div>
+        </header>
+        <section className="space-y-4">
+          <div className="overflow-hidden rounded-md border border-gray-200 bg-white">
+            <div className="flex flex-col gap-3 p-4 md:flex-row md:items-center md:justify-between">
+              <div className="flex flex-1 flex-wrap items-center gap-3">
+                <Input.Search
+                  allowClear
+                  placeholder="Buscar nombre, matrícula, bandera, puerto, RIF, servicio..."
+                  className="max-w-sm"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                />
+              </div>
+              <div className="flex justify-end">
+                <Button type="primary" icon={<PlusOutlined />} onClick={() => setDialog(true)}>
+                  Nueva embarcación
+                </Button>
+              </div>
+            </div>
+            <Table
+              size="small"
+              rowKey="id"
+              loading={loading}
+              columns={columns}
+              dataSource={filtered}
+              onChange={handleTableChange}
+              pagination={{ pageSize: 10, showSizeChanger: false }}
+            />
+          </div>
+        </section>
+      </div>
+      <Modal
+        open={dialog}
+        title={current ? `Editar embarcación #${current.id}` : "Nueva embarcación"}
+        onCancel={() => {
+          setCurrent(null);
+          setDialog(false);
+        }}
+        footer={null}
+        destroyOnClose
+      >
+        <VasselsForm
+          current={current}
+          onSaved={(saved) => {
+            setItems((prev) => {
+              const exists = prev.some((x) => x.id === saved.id);
+              return exists ? prev.map((x) => (x.id === saved.id ? saved : x)) : [saved, ...prev];
+            });
+          }}
+          onCancel={() => {
+            setCurrent(null);
+            setDialog(false);
+          }}
+        />
+      </Modal>
+    </main>
+  );
+}

--- a/frontend/src/features/vassels/index.ts
+++ b/frontend/src/features/vassels/index.ts
@@ -1,2 +1,6 @@
 export * from "@/features/vassels/services/vassels.service";
 export * from "@/features/vassels/types/vassel.types";
+export { default as VasselsForm } from "@/features/vassels/components/VasselsForm";
+export { default as VasselsList } from "@/features/vassels/components/VasselsList";
+export { vasselSchema } from "@/features/vassels/schemas/vassel.schema";
+export type { VasselFormValues } from "@/features/vassels/schemas/vassel.schema";

--- a/frontend/src/features/vassels/schemas/vassel.schema.ts
+++ b/frontend/src/features/vassels/schemas/vassel.schema.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+
+export const vasselSchema = z.object({
+  name: z.string().trim().min(1, "Requerido"),
+  registrationNumber: z
+    .string()
+    .trim()
+    .min(1, "Requerido")
+    .transform((s) => s.toUpperCase())
+    .refine((v) => /^[A-Z0-9\-]+$/.test(v), {
+      message: "Solo letras (A-Z), números (0-9) y guiones (-)",
+    }),
+  ismm: z
+    .string()
+    .trim()
+    .min(1, "Requerido")
+    .transform((s) => s.toUpperCase())
+    .refine((v) => /^\d+$/.test(v) || /^ISM-\d{4}$/.test(v), {
+      message: "Debe ser numérico o con formato ISM-####",
+    }),
+  flagState: z.string().trim().min(1, "Requerido"),
+  callSign: z.string().trim().min(1, "Requerido"),
+  portOfRegistry: z.string().trim().min(1, "Requerido"),
+  rif: z
+    .string()
+    .trim()
+    .transform((s) => s.toUpperCase())
+    .refine((v) => /^[JGVEP]-\d{8}-\d$/.test(v), {
+      message: "Formato inválido. Use J-12345678-9",
+    }),
+  serviceType: z.string().trim().min(1, "Requerido"),
+  constructionMaterial: z.string().trim().min(1, "Requerido"),
+  sternType: z.string().trim().min(1, "Requerido"),
+  fuelType: z.string().trim().min(1, "Requerido"),
+  navigationHours: z
+    .number()
+    .int({ message: "Debe ser entero" })
+    .nonnegative({ message: "No negativo" }),
+});
+
+export type VasselFormValues = z.infer<typeof vasselSchema>;

--- a/frontend/src/features/vassels/services/vassels.service.ts
+++ b/frontend/src/features/vassels/services/vassels.service.ts
@@ -42,6 +42,20 @@ export const vasselsService = {
     const { data } = await api.get<Vassel | ApiResult<Vassel>>(`${BASE}/${id}`);
     return unwrap<Vassel>(data);
   },
+
+  async create(payload: Partial<Vassel>): Promise<Vassel> {
+    const { data } = await api.post<Vassel | ApiResult<Vassel>>(`${BASE}/create`, payload);
+    return unwrap<Vassel>(data);
+  },
+
+  async update(id: number, payload: Partial<Vassel>): Promise<Vassel> {
+    const { data } = await api.put<Vassel | ApiResult<Vassel>>(`${BASE}/${id}`, payload);
+    return unwrap<Vassel>(data);
+  },
+
+  async remove(id: number): Promise<void> {
+    await api.delete(`${BASE}/${id}`);
+  },
 };
 
 export default vasselsService;

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -45,8 +45,8 @@ export const config = {
     // secciones principales protegidas
     "/maintenance",
     "/maintenance/:path*",
-    "/boats",
-    "/boats/:path*",
+    "/vassels",
+    "/vassels/:path*",
     "/inventory",
     "/inventory/:path*",
     "/config",


### PR DESCRIPTION
Introduces full CRUD support for 'Embarcaciones' (vessels) in the frontend, including new pages, form and list components, Zod schema validation, and service methods. Updates sidebar and middleware to use '/vassels' route instead of '/boats'.