### PR TITLE
Refactor service ticket UI to unify details and travels

### DIFF
--- a/frontend/src/features/inventary/components/VasselsList.tsx
+++ b/frontend/src/features/inventary/components/VasselsList.tsx
@@ -253,7 +253,6 @@ export default function VasselsList() {
           setDialog(false);
         }}
         footer={null}
-        destroyOnClose
       >
         <VasselsForm
           current={current}

--- a/frontend/src/features/service-ticket/components/ServiceTicketDetailForm.tsx
+++ b/frontend/src/features/service-ticket/components/ServiceTicketDetailForm.tsx
@@ -22,13 +22,13 @@ interface Props {
 }
 
 const defaultValues: Partial<ServiceTicketDetailInput> = {
-  serviceArea: "generico",
-  serviceType: "generico",
-  description: "generico",
+  serviceArea: "",
+  serviceType: "",
+  description: "",
   hoursTraveled: "00:00",
-  patronFullName: "generico",
-  marinerFullName: "generico",
-  captainFullName: "generico",
+  patronFullName: "",
+  marinerFullName: "",
+  captainFullName: "",
 };
 
 export const ServiceTicketDetailForm: React.FC<Props> = ({
@@ -51,6 +51,26 @@ export const ServiceTicketDetailForm: React.FC<Props> = ({
   React.useEffect(() => {
     if (current) reset({ ...current });
     else reset({ ...defaultValues, serviceTicketId });
+  }, [current, reset, serviceTicketId]);
+
+  // Auto-cargar detalle asociado si no se proporcionó `current`
+  React.useEffect(() => {
+    let abort = false;
+    (async () => {
+      if (!current && serviceTicketId) {
+        try {
+          const existing = await serviceTicketDetailService.getOneByServiceTicket(serviceTicketId);
+          if (!abort && existing) {
+            reset({ ...(existing as unknown as ServiceTicketDetailInput) });
+          }
+        } catch {
+          // ignorar si no hay detalle
+        }
+      }
+    })();
+    return () => {
+      abort = true;
+    };
   }, [current, reset, serviceTicketId]);
 
   const onSubmit = async (raw: ServiceTicketDetailInput) => {

--- a/frontend/src/features/service-ticket/components/ServiceTicketList.tsx
+++ b/frontend/src/features/service-ticket/components/ServiceTicketList.tsx
@@ -1,30 +1,27 @@
 "use client";
 
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { Button, DatePicker, Input, Modal, Popconfirm, Space, Table, Tooltip } from "antd";
+import { Button, DatePicker, Input, Modal, Popconfirm, Space, Table, Tooltip, Tag } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import type { TableProps } from "antd";
 import { useQuery } from "@tanstack/react-query";
 import {
-  ServiceTicketForm,
   type ServiceTicketListItem,
   serviceTicketService,
   ServiceTicketTemplate,
-
-  // Nuevos imports para Detalle
-  ServiceTicketDetailForm,
-  serviceTicketDetailService,
-  type ServiceTicketDetail,
-  // Imports para Travels
-  ServiceTicketTravelForm,
-  serviceTicketTravelService,
-  type ServiceTicketTravel,
+  type ServiceTicketData,
 } from "@/features/service-ticket";
 import { PlusOutlined, EditOutlined, DeleteOutlined } from "@ant-design/icons";
 import PDFGenerator from "@/components/pdf/PDFGenerator";
 
 import type { Dayjs } from "dayjs";
 import { showAlert } from "@/utils/showAlert";
+import ServiceTicketForm from "./ServiceTicketForm";
+import { serviceTicketDetailService } from "@/features/service-ticket/services/serviceTicketDetail.service";
+import type { ServiceTicketDetail } from "@/features/service-ticket/types/serviceTicketDetail.types";
+import { serviceTicketTravelService } from "@/features/service-ticket/services/serviceTicketTravel.service";
+import type { ServiceTicketTravel } from "@/features/service-ticket/types/serviceTicketTravel.types";
+import ServiceTicketTravelForm from "@/features/service-ticket/components/ServiceTicketTravelForm";
 
 export default function ServiceTicketList() {
   const [tableSort, setTableSort] = useState<string | undefined>("id,desc");
@@ -35,17 +32,20 @@ export default function ServiceTicketList() {
 
   const [items, setItems] = useState<ServiceTicketListItem[]>([]);
   const [current, setCurrent] = useState<ServiceTicketListItem | null>(null);
+  const [currentDetail, setCurrentDetail] = useState<ServiceTicketDetail | null>(null);
+  const [detailsByTicketId, setDetailsByTicketId] = useState<
+    Record<number, ServiceTicketDetail | null>
+  >({});
+  const [travelsByDetailId, setTravelsByDetailId] = useState<Record<number, ServiceTicketTravel[]>>(
+    {},
+  );
   const [dialog, setDialog] = useState(false);
 
-  // Estado para Detalles de Boleta
-  const [detailDialog, setDetailDialog] = useState(false);
-  const [detailTicket, setDetailTicket] = useState<ServiceTicketListItem | null>(null);
-
-  // Estado para Travels del Detail
-  const [detailEntity, setDetailEntity] = useState<ServiceTicketDetail | null>(null); // único
-  const [travelItems, setTravelItems] = useState<ServiceTicketTravel[]>([]);
-  const [travelCurrent, setTravelCurrent] = useState<ServiceTicketTravel | null>(null);
-  const [travelLoading, setTravelLoading] = useState(false);
+  // travel modal state (unified list + form)
+  const [travelsModalOpen, setTravelsModalOpen] = useState(false);
+  const [travelsModalDetailId, setTravelsModalDetailId] = useState<number | null>(null);
+  const [travelEditing, setTravelEditing] = useState<ServiceTicketTravel | null>(null);
+  const [showTravelForm, setShowTravelForm] = useState(false);
 
   // filters
   const [search, setSearch] = useState("");
@@ -55,33 +55,144 @@ export default function ServiceTicketList() {
     if (data?.content) setItems(data.content);
   }, [data]);
 
+  // Fetch details for the listed tickets to unify view
+  useEffect(() => {
+    let abort = false;
+    (async () => {
+      if (!items.length) {
+        setDetailsByTicketId({});
+        return;
+      }
+      try {
+        const results = await Promise.all(
+          items.map(async (it) => {
+            try {
+              const detail = await serviceTicketDetailService.getOneByServiceTicket(it.id);
+              return [it.id, detail] as [number, ServiceTicketDetail | null];
+            } catch {
+              return [it.id, null] as [number, ServiceTicketDetail | null];
+            }
+          }),
+        );
+        if (!abort) {
+          const map: Record<number, ServiceTicketDetail | null> = {};
+          for (const [id, det] of results) map[id] = det;
+          setDetailsByTicketId(map);
+        }
+      } catch {
+        // ignore
+      }
+    })();
+    return () => {
+      abort = true;
+    };
+  }, [items]);
+
+  // Fetch travels for each available detail
+  useEffect(() => {
+    let abort = false;
+    (async () => {
+      const detailIds = Object.values(detailsByTicketId)
+        .filter((d): d is ServiceTicketDetail => !!d)
+        .map((d) => d.id);
+      if (!detailIds.length) {
+        setTravelsByDetailId({});
+        return;
+      }
+      try {
+        const results = await Promise.all(
+          detailIds.map(async (detailId) => {
+            try {
+              const travels = await serviceTicketTravelService.listByDetail(detailId);
+              return [detailId, travels] as [number, ServiceTicketTravel[]];
+            } catch {
+              return [detailId, [] as ServiceTicketTravel[]] as [number, ServiceTicketTravel[]];
+            }
+          }),
+        );
+        if (!abort) {
+          const map: Record<number, ServiceTicketTravel[]> = {};
+          for (const [id, travels] of results) map[id] = travels;
+          setTravelsByDetailId(map);
+        }
+      } catch {
+        // ignore
+      }
+    })();
+    return () => {
+      abort = true;
+    };
+  }, [detailsByTicketId]);
+
+  // Lazy load travels when opening modal for a specific detail
+  useEffect(() => {
+    (async () => {
+      if (!travelsModalOpen || travelsModalDetailId == null) return;
+      if (travelsByDetailId[travelsModalDetailId]) return;
+      try {
+        const travels = await serviceTicketTravelService.listByDetail(travelsModalDetailId);
+        setTravelsByDetailId((prev) => ({ ...prev, [travelsModalDetailId]: travels }));
+      } catch {
+        // ignore
+      }
+    })();
+  }, [travelsModalOpen, travelsModalDetailId, travelsByDetailId]);
+
+  const openTravelsModal = (detailId: number, openForm = false, editing?: ServiceTicketTravel) => {
+    setTravelsModalDetailId(detailId);
+    setTravelEditing(editing ?? null);
+    setShowTravelForm(openForm);
+    setTravelsModalOpen(true);
+  };
+
+  const closeTravelsModal = () => {
+    setTravelsModalOpen(false);
+    setTravelsModalDetailId(null);
+    setTravelEditing(null);
+    setShowTravelForm(false);
+  };
+
   const filtered = useMemo(() => {
     const term = search.toLowerCase();
     return items.filter((i) => {
+      const d = detailsByTicketId[i.id];
+      const travels = d ? travelsByDetailId[d.id] || [] : [];
       const mSearch =
         !term ||
         i.vesselAttended.toLowerCase().includes(term) ||
-
         i.vesselName.toLowerCase().includes(term) ||
-
         i.solicitedBy.toLowerCase().includes(term) ||
         i.responsibleUsername.toLowerCase().includes(term) ||
         i.reportTravelNro.toLowerCase().includes(term) ||
-        i.code.toLowerCase().includes(term);
+        i.code.toLowerCase().includes(term) ||
+        (d?.serviceArea?.toLowerCase?.().includes(term) ?? false) ||
+        (d?.serviceType?.toLowerCase?.().includes(term) ?? false) ||
+        (d?.description?.toLowerCase?.().includes(term) ?? false) ||
+        (d?.patronFullName?.toLowerCase?.().includes(term) ?? false) ||
+        (d?.marinerFullName?.toLowerCase?.().includes(term) ?? false) ||
+        (d?.captainFullName?.toLowerCase?.().includes(term) ?? false) ||
+        travels.some(
+          (t) =>
+            t.origin.toLowerCase().includes(term) ||
+            t.destination.toLowerCase().includes(term) ||
+            t.departureTime.toLowerCase().includes(term) ||
+            t.arrivalTime.toLowerCase().includes(term),
+        );
       const mDate = (() => {
         if (!dateRange) return true;
         const [from, to] = dateRange;
         if (!from || !to) return true;
-        const [d, m, y] = i.travelDate.split("-").map((v) => parseInt(v, 10));
-        const dt = new Date(y, m - 1, d).getTime();
+        const [dDay, dMonth, dYear] = i.travelDate.split("-").map((v) => parseInt(v, 10));
+        const dt = new Date(dYear, dMonth - 1, dDay).getTime();
         return dt >= from.startOf("day").valueOf() && dt <= to.endOf("day").valueOf();
       })();
       return mSearch && mDate;
     });
-  }, [items, search, dateRange]);
+  }, [items, search, dateRange, detailsByTicketId, travelsByDetailId]);
 
   const onClose = useCallback(() => {
     setCurrent(null);
+    setCurrentDetail(null);
     setDialog(false);
   }, []);
 
@@ -105,38 +216,6 @@ export default function ServiceTicketList() {
       setTableSort(order && field ? `${field},${order}` : undefined);
     }
     void refetch();
-  };
-
-  // Abrir modal de detalles para una boleta
-  const openDetails = async (ticket: ServiceTicketListItem) => {
-    setDetailTicket(ticket);
-    setDetailDialog(true);
-    setDetailEntity(null);
-    setTravelItems([]);
-    setTravelCurrent(null);
-
-    try {
-      // Obtener (o crear) el único detalle
-      const detail = await serviceTicketDetailService.getOneByServiceTicket(ticket.id);
-      if (!detail) {
-        // si no existe, preparamos el form vacío; el usuario lo creará con el form
-        setDetailEntity(null);
-      } else {
-        setDetailEntity(detail);
-        // cargar travels
-        setTravelLoading(true);
-        const travels = await serviceTicketTravelService.listByDetail(detail.id);
-        setTravelItems(travels);
-      }
-    } catch (e) {
-      await showAlert(
-        "No se pudieron cargar los detalles",
-        (e as Error)?.message || "Intenta nuevamente.",
-        "error",
-      );
-    } finally {
-      setTravelLoading(false);
-    }
   };
 
   // Columnas principales
@@ -184,23 +263,76 @@ export default function ServiceTicketList() {
     { title: "Embarcación", dataIndex: "vesselName", key: "vesselName" },
 
     { title: "Responsable", dataIndex: "responsibleUsername", key: "responsibleUsername" },
+
+    // Campos del detalle
+    {
+      title: "Área servicio",
+      key: "serviceArea",
+      render: (_: unknown, record) => detailsByTicketId[record.id]?.serviceArea ?? "-",
+    },
+    {
+      title: "Tipo servicio",
+      key: "serviceType",
+      render: (_: unknown, record) => detailsByTicketId[record.id]?.serviceType ?? "-",
+    },
+    {
+      title: "Horas",
+      key: "hoursTraveled",
+      width: 80,
+      render: (_: unknown, record) => detailsByTicketId[record.id]?.hoursTraveled ?? "-",
+    },
+    {
+      title: "Patrón",
+      key: "patronFullName",
+      render: (_: unknown, record) => detailsByTicketId[record.id]?.patronFullName ?? "-",
+    },
+    {
+      title: "Marinero",
+      key: "marinerFullName",
+      render: (_: unknown, record) => detailsByTicketId[record.id]?.marinerFullName ?? "-",
+    },
+    {
+      title: "Capitán",
+      key: "captainFullName",
+      render: (_: unknown, record) => detailsByTicketId[record.id]?.captainFullName ?? "-",
+    },
+    {
+      title: "Viajes",
+      key: "travelsCount",
+      render: (_: unknown, record) => {
+        const detail = detailsByTicketId[record.id];
+        const count = detail ? travelsByDetailId[detail.id]?.length || 0 : 0;
+        return (
+          <Tag
+            color={count ? "blue" : undefined}
+            style={{ cursor: detail ? "pointer" : "not-allowed" }}
+            onClick={() => detail && openTravelsModal(detail.id)}
+          >
+            {count} viajes
+          </Tag>
+        );
+      },
+    },
+
     {
       title: "Acciones",
       key: "acciones",
       align: "right" as const,
       render: (_: unknown, record) => (
         <Space size="small" onClick={(e) => e.stopPropagation()}>
-
-          <Tooltip title="Detalle">
-            <Button size="small" type="text" onClick={() => void openDetails(record)}>
-              Detalle
-            </Button>
-          </Tooltip>
-
           <Tooltip title="Imprimir / Vista previa">
             <PDFGenerator
               template={ServiceTicketTemplate}
-              data={record}
+              data={
+                {
+                  ...(record as unknown as ServiceTicketData),
+                  detail: detailsByTicketId[record.id] ?? null,
+                  travels: detailsByTicketId[record.id]
+                    ? travelsByDetailId[(detailsByTicketId[record.id] as ServiceTicketDetail).id] ||
+                      []
+                    : [],
+                } as ServiceTicketData
+              }
               fileName={`boleta-servicio-${record.id ?? "sin-id"}.pdf`}
             />
           </Tooltip>
@@ -211,7 +343,23 @@ export default function ServiceTicketList() {
               icon={<EditOutlined />}
               onClick={() => {
                 setCurrent(record);
+                setCurrentDetail(detailsByTicketId[record.id] ?? null);
                 setDialog(true);
+              }}
+            />
+          </Tooltip>
+          <Tooltip title="Ver viajes / Agregar">
+            <Button
+              size="small"
+              type="text"
+              icon={<PlusOutlined />}
+              onClick={() => {
+                const detail = detailsByTicketId[record.id];
+                if (!detail) {
+                  void showAlert("Sin detalle", "Primero crea el detalle.", "warning");
+                  return;
+                }
+                openTravelsModal(detail.id, true);
               }}
             />
           </Tooltip>
@@ -223,6 +371,11 @@ export default function ServiceTicketList() {
               try {
                 await serviceTicketService.remove(record.id);
                 setItems((prev) => prev.filter((x) => x.id !== record.id));
+                setDetailsByTicketId((prev) => {
+                  const copy = { ...prev };
+                  delete copy[record.id];
+                  return copy;
+                });
               } catch (e) {
                 await showAlert(
                   "Error al eliminar",
@@ -240,48 +393,6 @@ export default function ServiceTicketList() {
       ),
     },
   ];
-
-  const travelColumns: ColumnsType<ServiceTicketTravel> = [
-    { title: "Origen", dataIndex: "origin", key: "origin" },
-    { title: "Destino", dataIndex: "destination", key: "destination" },
-    { title: "Salida", dataIndex: "departureTime", key: "departureTime", width: 110 },
-    { title: "Llegada", dataIndex: "arrivalTime", key: "arrivalTime", width: 110 },
-    { title: "Total", dataIndex: "totalTraveledTime", key: "totalTraveledTime", width: 90 },
-    {
-      title: "Acciones",
-      key: "actions",
-      align: "right" as const,
-      render: (_: unknown, rec) => (
-        <Space size="small">
-          <Button size="small" type="text" onClick={() => setTravelCurrent(rec)}>
-            Editar
-          </Button>
-          <Popconfirm
-            title="Eliminar viaje"
-            okText="Eliminar"
-            cancelText="Cancelar"
-            onConfirm={async () => {
-              try {
-                await serviceTicketTravelService.remove(rec.id);
-                setTravelItems((prev) => prev.filter((d) => d.id !== rec.id));
-              } catch (e) {
-                await showAlert(
-                  "Error al eliminar",
-                  (e as Error)?.message || "No se pudo eliminar el viaje",
-                  "error",
-                );
-              }
-            }}
-          >
-            <Button size="small" type="text" danger>
-              Eliminar
-            </Button>
-          </Popconfirm>
-        </Space>
-      ),
-    },
-  ];
-
 
   return (
     <main className="min-h-screen bg-gray-50 p-8">
@@ -316,7 +427,15 @@ export default function ServiceTicketList() {
                 />
               </div>
               <div className="flex justify-end">
-                <Button type="primary" icon={<PlusOutlined />} onClick={() => setDialog(true)}>
+                <Button
+                  type="primary"
+                  icon={<PlusOutlined />}
+                  onClick={() => {
+                    setCurrent(null);
+                    setCurrentDetail(null);
+                    setDialog(true);
+                  }}
+                >
                   Nueva boleta
                 </Button>
               </div>
@@ -334,140 +453,132 @@ export default function ServiceTicketList() {
           </div>
         </section>
       </div>
+
+      {/* Dialogo de crear/editar boleta + detalle */}
       <Modal
+        title={current ? "Editar boleta" : "Nueva boleta"}
         open={dialog}
-        title={
-          <div className="mb-2 text-center md:text-left">
-            <div className="primary border-b-2 border-blue-600 pb-2">
-              <h2 className="text-900 mb-2 flex items-center justify-center text-2xl font-bold text-gray-900 md:justify-start">
-                {current ? `Modificar Boleta #${current.id}` : "Crear Boleta"}
-              </h2>
-            </div>
-          </div>
-        }
         onCancel={onClose}
         footer={null}
       >
-
-        {current?.id && (
-          <div className="mb-3 flex justify-end">
-            <Button onClick={() => void openDetails(current)}>Detalle</Button>
-          </div>
-        )}
-        <ServiceTicketForm items={items} setItems={setItems} current={current} onClose={onClose} />
+        <ServiceTicketForm
+          items={items}
+          setItems={setItems}
+          current={current}
+          onClose={onClose}
+          currentDetail={currentDetail}
+          initialStep={current ? 1 : 0}
+          onDetailSaved={(d) =>
+            setDetailsByTicketId((prev) => ({ ...(prev || {}), [d.serviceTicketId]: d }))
+          }
+        />
       </Modal>
 
-      {/* Modal de Detalles */}
+      {/* Dialogo de agregar/editar viaje unificado en modal de lista */}
       <Modal
-        open={detailDialog}
-        onCancel={() => {
-          setDetailDialog(false);
-          setDetailTicket(null);
-          setDetailEntity(null);
-          setTravelItems([]);
-          setTravelCurrent(null);
-        }}
+        title={travelsModalDetailId ? `Viajes del detalle #${travelsModalDetailId}` : "Viajes"}
+        open={travelsModalOpen}
+        onCancel={closeTravelsModal}
         footer={null}
-        width={900}
-        title={
-          <div className="mb-2 text-center md:text-left">
-            <div className="primary border-b-2 border-blue-600 pb-2">
-              <h2 className="text-900 mb-2 flex items-center justify-center text-2xl font-bold text-gray-900 md:justify-start">
-                {detailTicket ? `Detalle de Boleta #${detailTicket.id}` : "Detalle"}
-              </h2>
-              {detailTicket && (
-                <p className="text-sm text-gray-600">{`${detailTicket.vesselName} — ${detailTicket.travelDate}`}</p>
-              )}
-            </div>
-          </div>
-        }
       >
-        {detailTicket && (
-          <div className="space-y-6">
-            {/* Sección: Detalle único */}
-            <div className="rounded-md border border-gray-200 bg-white p-3">
-              <div className="mb-2 flex items-center justify-between">
-                <h3 className="text-lg font-semibold">
-                  {detailEntity ? `Detalle #${detailEntity.id}` : "Nuevo detalle"}
-                </h3>
-                {/* Se elimina botón 'Nuevo' para evitar múltiples detalles por boleta */}
+        {travelsModalDetailId != null && (
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div className="text-sm text-gray-600">
+                {travelsByDetailId[travelsModalDetailId]?.length || 0} viajes
               </div>
-              <ServiceTicketDetailForm
-                serviceTicketId={detailTicket.id}
-                current={detailEntity}
-                onSaved={async (saved) => {
-                  setDetailEntity(saved);
-                  // Actualizar items legacy si se usan en alguna parte
-                  // setDetailItems([saved]);
-                  // Cargar travels del nuevo/actual detail
-                  setTravelLoading(true);
-                  try {
-                    const travels = await serviceTicketTravelService.listByDetail(saved.id);
-                    setTravelItems(travels);
-                  } finally {
-                    setTravelLoading(false);
-                  }
+              <Button
+                size="small"
+                icon={<PlusOutlined />}
+                onClick={() => {
+                  setTravelEditing(null);
+                  setShowTravelForm(true);
                 }}
+              >
+                Agregar viaje
+              </Button>
+            </div>
+
+            {showTravelForm && (
+              <ServiceTicketTravelForm
+                serviceTicketDetailId={travelsModalDetailId}
+                current={travelEditing ?? undefined}
+                onSaved={(t) => {
+                  setTravelsByDetailId((prev) => {
+                    const list = prev[travelsModalDetailId] || [];
+                    const exists = list.some((x) => x.id === t.id);
+                    const newList = exists
+                      ? list.map((x) => (x.id === t.id ? t : x))
+                      : [t, ...list];
+                    return { ...prev, [travelsModalDetailId]: newList };
+                  });
+                  setShowTravelForm(false);
+                  setTravelEditing(null);
+                }}
+                onClose={() => setShowTravelForm(false)}
               />
-            </div>
+            )}
 
-            {/* Sección: Travels del detalle */}
-            <div className="rounded-md border border-gray-200 bg-white p-3">
-              <div className="mb-2 flex items-center justify-between">
-                <h3 className="text-base font-semibold">Viajes</h3>
-                <Button
-                  onClick={() => setTravelCurrent(null)}
-                  type="dashed"
-                  disabled={!detailEntity}
-                >
-                  Nuevo viaje
-                </Button>
-              </div>
-
-              {detailEntity ? (
-                <ServiceTicketTravelForm
-                  serviceTicketDetailId={detailEntity.id}
-                  current={travelCurrent}
-                  onSaved={(saved) => {
-                    setTravelItems((prev) => {
-                      const idx = prev.findIndex((d) => d.id === saved.id);
-                      if (idx >= 0) {
-                        const copy = [...prev];
-                        copy[idx] = saved;
-                        return copy;
-                      }
-                      return [saved, ...prev];
-                    });
-                    setTravelCurrent(null);
-                  }}
-                  onClose={() => setTravelCurrent(null)}
-                />
-              ) : (
-                <p className="text-sm text-gray-600">
-                  Guarda el detalle para habilitar el registro de viajes.
-                </p>
-              )}
-
-              <div className="mt-3">
-                <Table
-                  size="small"
-                  rowKey="id"
-                  loading={travelLoading}
-                  columns={travelColumns}
-                  dataSource={travelItems}
-                  pagination={{ pageSize: 5, showSizeChanger: false }}
-                />
-                {!detailEntity && (
-                  <p className="mt-2 text-xs text-gray-500">
-                    Crea y guarda el detalle antes de registrar viajes.
-                  </p>
-                )}
-              </div>
-            </div>
+            <Table
+              size="small"
+              rowKey="id"
+              columns={[
+                { title: "Origen", dataIndex: "origin", key: "origin" },
+                { title: "Destino", dataIndex: "destination", key: "destination" },
+                { title: "Salida", dataIndex: "departureTime", key: "departureTime", width: 90 },
+                { title: "Llegada", dataIndex: "arrivalTime", key: "arrivalTime", width: 90 },
+                {
+                  title: "Acciones",
+                  key: "actions",
+                  align: "right" as const,
+                  render: (_: unknown, tr: ServiceTicketTravel) => (
+                    <Space size="small">
+                      <Button
+                        size="small"
+                        type="link"
+                        onClick={() => {
+                          setTravelEditing(tr);
+                          setShowTravelForm(true);
+                        }}
+                      >
+                        Editar
+                      </Button>
+                      <Popconfirm
+                        title="Eliminar viaje?"
+                        okText="Eliminar"
+                        cancelText="Cancelar"
+                        onConfirm={async () => {
+                          try {
+                            await serviceTicketTravelService.remove(tr.id);
+                            setTravelsByDetailId((prev) => ({
+                              ...prev,
+                              [travelsModalDetailId]: (prev[travelsModalDetailId] || []).filter(
+                                (x) => x.id !== tr.id,
+                              ),
+                            }));
+                          } catch (e) {
+                            await showAlert(
+                              "Error",
+                              (e as Error)?.message || "No se pudo eliminar el viaje",
+                              "error",
+                            );
+                          }
+                        }}
+                      >
+                        <Button size="small" type="link" danger>
+                          Eliminar
+                        </Button>
+                      </Popconfirm>
+                    </Space>
+                  ),
+                },
+              ]}
+              dataSource={travelsByDetailId[travelsModalDetailId] || []}
+              pagination={false}
+            />
           </div>
         )}
       </Modal>
-
     </main>
   );
 }

--- a/frontend/src/features/service-ticket/index.ts
+++ b/frontend/src/features/service-ticket/index.ts
@@ -9,9 +9,7 @@ export * from "./types/serviceTicketDetail.types";
 export * from "./schemas/serviceTicketDetail.schema";
 export * from "./services/serviceTicketDetail.service";
 export { ServiceTicketDetailForm } from "./components/ServiceTicketDetailForm";
-// Exports para Travels
 export * from "./types/serviceTicketTravel.types";
 export * from "./schemas/serviceTicketTravel.schema";
 export * from "./services/serviceTicketTravel.service";
 export { ServiceTicketTravelForm } from "./components/ServiceTicketTravelForm";
-

--- a/frontend/src/features/service-ticket/services/serviceTicketDetail.service.ts
+++ b/frontend/src/features/service-ticket/services/serviceTicketDetail.service.ts
@@ -24,7 +24,8 @@ const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "obj
 function normalizeArrayResponse<T>(val: unknown): T[] {
   const data = isApiResult<unknown>(val) ? val.data : val;
   if (Array.isArray(data)) return data as T[];
-  if (isRecord(data) && Array.isArray(data.content)) return data.content as T[];
+  if (isRecord(data) && Array.isArray((data as Record<string, unknown>).content))
+    return (data as Record<string, unknown>).content as T[];
   if (isRecord(data) && Object.keys(data).length > 0) return [data as T];
   return [];
 }
@@ -56,7 +57,7 @@ export const serviceTicketDetailService = {
     return unwrap<ServiceTicketDetail>(data);
   },
   async listByServiceTicket(serviceTicketId: number): Promise<ServiceTicketDetail[]> {
-    const { data } = await api.get<unknown>(`${DETAIL_BASE}?serviceTicketId=${serviceTicketId}`);
+    const { data } = await api.get<unknown>(`${DETAIL_BASE}/by-ticket/${serviceTicketId}`);
     return normalizeArrayResponse<ServiceTicketDetail>(data);
   },
   async getOneByServiceTicket(serviceTicketId: number): Promise<ServiceTicketDetail | null> {

--- a/frontend/src/features/vassel-item/components/VasselItemList.tsx
+++ b/frontend/src/features/vassel-item/components/VasselItemList.tsx
@@ -190,7 +190,6 @@ export default function VasselItemList({ vasselId }: Props) {
           setDialog(false);
         }}
         footer={null}
-        destroyOnClose
       >
         <VasselItemForm
           vasselId={vasselId}

--- a/frontend/src/features/vassels/components/VasselsList.tsx
+++ b/frontend/src/features/vassels/components/VasselsList.tsx
@@ -253,7 +253,6 @@ export default function VasselsList() {
           setDialog(false);
         }}
         footer={null}
-        destroyOnClose
       >
         <VasselsForm
           current={current}


### PR DESCRIPTION
Service ticket list now displays detail and travel info inline, with modals for editing details and travels. ServiceTicketForm supports step navigation between ticket and detail, and ServiceTicketTemplate PDF includes both detail and travel data. Improves UX by consolidating related data and actions, and removes default values from detail form.